### PR TITLE
A proposed definition of `IsRupert`

### DIFF
--- a/Rupert.lean
+++ b/Rupert.lean
@@ -1,14 +1,17 @@
 import Mathlib
+open Matrix
 
-
-def ThreeSpace := EuclideanSpace ℝ (Fin 3)
+abbrev ThreeSpace := EuclideanSpace ℝ (Fin 3)
+abbrev TwoSpace := EuclideanSpace ℝ (Fin 2)
 
 notation "ℝ³" => ThreeSpace
+notation "ℝ²" => TwoSpace
 
-def IsRupert (p : Set ℝ³) : Prop := sorry
+def project32 (v : ℝ³) : ℝ² := ![v 0, v 1]
 
-#check Matrix (Fin 3) (Fin 3) ℚ
-
-def m1 : Matrix (Fin 3) (Fin 3) ℚ := !![1, 2, 3; 4, 5, 6; 7, 8, 9]
-
-#eval m1 * m1
+def IsRupert (p : Set ℝ³) : Prop := 
+   let SO3 := Matrix.specialOrthogonalGroup (Fin 3) ℝ
+   ∃ R₁ ∈ SO3, ∃ R₂ ∈ SO3, ∃ T : ℝ², 
+   let Im₁ := Set.image (λ t ↦ project32 (R₁ *ᵥ t)) p
+   let Im₂ := Set.image (λ t ↦ T + project32 (R₂ *ᵥ t)) p
+   Im₂ ⊆ interior Im₁


### PR DESCRIPTION
The reason I changed `def` to `abbrev` for `ℝ³` and `ℝ²` was that otherwise the instances of `HAdd` and `TopologicalSpace` aren't visible. I want them to use for adding vectors, and for asking for the interior of `Im₁`, respectively. Perhaps there's a better way of handling this.