### PR TITLE
Remove outstanding sorrys

### DIFF
--- a/Rupert/Cube.lean
+++ b/Rupert/Cube.lean
@@ -14,37 +14,4 @@ def cube : Fin 8 → ℝ³ := ![
   ![-1, -1, -1],
   ![-1,  1, -1]]
 
-section rotations
-open Real
-open Matrix
--- Rotate by just enough about the y-axis to bring (1, 0, √2/2) to (0, 0, z) for some z.
--- Take cos⁻¹ to find out the angle.
-def outer_rot2 : Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
-  sorry
-
--- Rotate 45° by x-axis
-noncomputable
-def outer_rot1 : Matrix.specialOrthogonalGroup (Fin 3) ℝ :=
- let q : Quaternion ℝ := ⟨cos (π/8), sin (π/8), 0, 0⟩
- have qnz : q.normSq ≠ 0 := by
-   rw [Quaternion.normSq_def']
-   simp only [q, ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, zero_pow,
-              add_zero, cos_sq_add_sin_sq, one_ne_zero]
- let M := matrix_of_quat q
- let res := M *ᵥ ![1,1,1]
- have : res = ![1, √2, 0] := by
-   simp only [res, M, matrix_of_quat, q, Matrix.mulVec]
-   simp [Matrix.of_apply]
-   ext i; fin_cases i
-   · simp only [Fin.zero_eta, Fin.isValue, Pi.add_apply, Function.comp_apply, cons_val_zero,
-     head_cons, tail_cons, add_zero]; sorry
-   · sorry
-   · sorry
- ⟨M, matrix_of_quat_is_s03 qnz⟩
-
-noncomputable
-def outer_rot := outer_rot2 * outer_rot1
-
-end rotations
-
 proof_wanted rupert : IsRupert cube

--- a/Rupert/Quaternion.lean
+++ b/Rupert/Quaternion.lean
@@ -151,25 +151,7 @@ def rotateToTarget (src tgt : ℝ³) : Quaternion ℝ :=
    let v := src ×₃ tgt
    ⟨cos (θ/2), sin (θ/2) * v 0, sin (θ/2) * v 1, sin (θ/2) * v 2⟩
 
-theorem rotate_parallel_target (src tgt : ℝ³) : ∃ ℓ : ℝ,
-        matrix_of_quat (rotateToTarget src tgt) *ᵥ src = ℓ • tgt := by
-  use ?wit
-  · let θ := cos⁻¹ (inner _ src tgt / (2 * ‖src‖  * ‖tgt‖))
-    let v := src ×₃ tgt
-    simp only [matrix_of_quat]
-    rw [show rotateToTarget src tgt = ⟨cos (θ/2), sin (θ/2) * v 0, sin (θ/2) * v 1, sin (θ/2) * v 2⟩ by rfl]
-    dsimp only;
-    ext i; fin_cases i;
-    · beta_reduce; simp only [Matrix.mulVec];
-      dsimp only [Fin.isValue, Fin.zero_eta, of_apply, cons_val_zero, PiLp.smul_apply, smul_eq_mul];
-      dsimp only [dotProduct]
-      simp only [Fin.sum_univ_succ, Fin.sum_univ_zero]
-      simp only [Fin.isValue, cons_val_zero, Fin.succ_zero_eq_one, cons_val_one,
-        Fin.succ_one_eq_two, cons_val, add_zero]
-      dsimp only [v, crossProduct]; simp;
-      sorry
-    · sorry
-    · sorry
-  · sorry
+proof_wanted rotate_parallel_target (src tgt : ℝ³) : ∃ ℓ : ℝ,
+        matrix_of_quat (rotateToTarget src tgt) *ᵥ src = ℓ • tgt
 
 end Rotations

--- a/Rupert/Set.lean
+++ b/Rupert/Set.lean
@@ -18,8 +18,3 @@ def IsRupertPair (inner outer : Set ℝ³) : Prop :=
     are rotations and translations such that one 2-dimensional "shadow" of S can
     be made to fit entirely inside the interior of another such "shadow". -/
 def IsRupertSet (S : Set ℝ³) : Prop := IsRupertPair S S
-
-/-- This is a lemma required for showing that the rupert property as defined
-    for convex polyhedra is equivalent to the above property. -/
-lemma affine_imp_closed {n m : ℕ} (f : E n →ᵃ[ℝ] E m) : IsClosedMap f :=
- sorry


### PR DESCRIPTION
- Simply removed the WIP proof of the cube being rupert from Cube.lean. I'll continue this on a branch. Most of this work will get obviated in my current thinking anyway, by more general-purpose rotation lemmas.

- Removed the lemma `rotate_parallel_target` for now, also to be continued in a branch if necessary, replaced by `proof_wanted`.

- Removed a false (!) unproved lemma `affine_imp_closed` from Set.lean. I don't know what I was thinking. Even a convex closed set can fail to be closed under the image of an affine map. For example, projecting $\\{ (x, y) ∈ \\mathbb{R}^2 | xy > 1, x > 0 \\}$ down to the x-axis yields the non-closed set $\\{ x \in \\mathbb{R} | x > 0 \\}$.

- Fixed the proofs in RelatingRupertDefs.lean to not need that lemma. Showing that the projection of the convex hull of a finite set of points is closed is still true, simply by reasoning that the projection of the rotation/translation of the convex hull of a finite set is the same thing as the convex hull of the projection of the rotation/translation of a finite set of points.