### PR TITLE
Refactor RelatingRupertDefs into separate files

### DIFF
--- a/Rupert.lean
+++ b/Rupert.lean
@@ -6,7 +6,8 @@ import Rupert.FinCases
 import Rupert.Icosahedron
 import Rupert.MatrixSimps
 import Rupert.Quaternion
-import Rupert.RelatingRupertDefs
+import Rupert.Equivalences.RupertEquivRupertPrime
+import Rupert.Equivalences.RupertEquivRupertSet
 import Rupert.Set
 import Rupert.SnubCube
 import Rupert.Square

--- a/Rupert/Cube.lean
+++ b/Rupert/Cube.lean
@@ -2,7 +2,7 @@ import Rupert.Basic
 import Rupert.Convex
 import Rupert.Quaternion
 import Rupert.MatrixSimps
-import Rupert.RelatingRupertDefs
+import Rupert.Equivalences.RupertEquivRupertPrime
 
 namespace Cube
 open Matrix

--- a/Rupert/Equivalences/RupertEquivRupertSet.lean
+++ b/Rupert/Equivalences/RupertEquivRupertSet.lean
@@ -1,0 +1,32 @@
+import Mathlib
+import Rupert.Basic
+import Rupert.Set
+import Rupert.Equivalences.Util
+open Matrix
+
+theorem rupert_imp_rupert_set {ι : Type} [Fintype ι] (v : ι → ℝ³) :
+    IsRupert v → IsRupertSet (convexHull ℝ (Set.range v)) := by
+  intro ⟨ inner_rot, inner_so3, inner_offset, outer_rot, outer_so3, rupert⟩
+  use inner_rot, inner_so3, inner_offset, outer_rot, outer_so3
+  intro inner_shadow outer_shadow
+  let tx := full_transform_affine inner_offset ⟨inner_rot, inner_so3⟩
+
+  have inner_shadow_closed : IsClosed inner_shadow := by
+    have inner_shadow_is_txed_convex_hull : tx '' (convexHull ℝ (Set.range v)) = convexHull ℝ (tx '' Set.range v) := by
+      apply AffineMap.image_convexHull
+    change inner_shadow = convexHull ℝ (tx '' Set.range v) at inner_shadow_is_txed_convex_hull
+    rw [inner_shadow_is_txed_convex_hull, ← Set.range_comp]
+    exact Set.Finite.isClosed_convexHull (Set.finite_range (tx ∘ v))
+
+  rw [closure_eq_iff_isClosed.mpr inner_shadow_closed]
+  exact rupert
+
+theorem rupert_set_imp_rupert {ι : Type} [Fintype ι] (v : ι → ℝ³) :
+    IsRupertSet (convexHull ℝ (Set.range v)) → IsRupert v := by
+  intro ⟨ inner_rot, inner_so3, inner_offset, outer_rot, outer_so3, rupert⟩
+  use inner_rot, inner_so3, inner_offset, outer_rot, outer_so3
+  intro _ _ _ _ ha
+  exact rupert (subset_closure ha)
+
+theorem rupert_iff_rupert_set {ι : Type} [Fintype ι] (v : ι → ℝ³) : IsRupert v ↔ IsRupertSet (convexHull ℝ (Set.range v)) :=
+  ⟨rupert_imp_rupert_set v, rupert_set_imp_rupert v⟩

--- a/Rupert/Equivalences/Util.lean
+++ b/Rupert/Equivalences/Util.lean
@@ -1,0 +1,40 @@
+import Mathlib
+import Rupert.Basic
+import Rupert.Set
+open Pointwise
+open Matrix
+
+/-- Projecting from ℝ³ to ℝ² is linear -/
+noncomputable
+def proj_xy_linear : ℝ³ →ₗ[ℝ] ℝ² :=
+  {
+   toFun := proj_xy,
+   map_add' := by
+     intro x y;
+     ext i; fin_cases i;
+     · simp only [proj_xy, Fin.isValue, PiLp.add_apply, Fin.zero_eta, cons_val_zero];
+     · simp only [proj_xy, Fin.isValue, PiLp.add_apply, Fin.mk_one, cons_val_one, cons_val_fin_one]
+   ,
+   map_smul' := by
+     intro x y; ext i; fin_cases i;
+     · simp only [proj_xy, Fin.isValue, PiLp.smul_apply, smul_eq_mul, Fin.zero_eta, cons_val_zero,
+       RingHom.id_apply];
+     · simp only [proj_xy, Fin.isValue, PiLp.smul_apply, smul_eq_mul, Fin.mk_one, cons_val_one,
+       cons_val_fin_one, RingHom.id_apply]
+   }
+
+noncomputable
+def rotation_affine (rot : SO3) : ℝ³ →ᵃ[ℝ] ℝ³ := (Matrix.mulVecLin rot).toAffineMap
+
+/-- Translating is affine. -/
+noncomputable
+def offset_affine (off : E 2) : ℝ² →ᵃ[ℝ] ℝ² :=
+  {toFun v := off + v, linear := LinearMap.id, map_vadd' p v := add_vadd_comm v off p }
+
+noncomputable
+def proj_xy_rotation_is_affine (rot : SO3) : ℝ³ →ᵃ[ℝ] ℝ² :=
+  AffineMap.comp proj_xy_linear.toAffineMap (rotation_affine rot)
+
+noncomputable
+def full_transform_affine (off : E 2) (rot : SO3) : ℝ³ →ᵃ[ℝ] ℝ² :=
+  AffineMap.comp (offset_affine off) (proj_xy_rotation_is_affine rot)

--- a/Rupert/Icosahedron.lean
+++ b/Rupert/Icosahedron.lean
@@ -3,7 +3,7 @@ import Rupert.Basic
 import Rupert.Convex
 import Rupert.MatrixSimps
 import Rupert.Quaternion
-import Rupert.RelatingRupertDefs
+import Rupert.Equivalences.RupertEquivRupertPrime
 
 namespace Icosahedron
 

--- a/Rupert/Square.lean
+++ b/Rupert/Square.lean
@@ -1,6 +1,6 @@
 import Rupert.Basic
 import Rupert.Convex
-import Rupert.RelatingRupertDefs
+import Rupert.Equivalences.RupertEquivRupertPrime
 
 namespace Square
 

--- a/Rupert/Tetrahedron.lean
+++ b/Rupert/Tetrahedron.lean
@@ -2,7 +2,7 @@ import Rupert.Basic
 import Rupert.Convex
 import Rupert.MatrixSimps
 import Rupert.Quaternion
-import Rupert.RelatingRupertDefs
+import Rupert.Equivalences.RupertEquivRupertPrime
 
 namespace Tetrahedron
 

--- a/Rupert/TriakisTetrahedron.lean
+++ b/Rupert/TriakisTetrahedron.lean
@@ -3,7 +3,7 @@ import Rupert.Convex
 import Rupert.FinCases
 import Rupert.MatrixSimps
 import Rupert.Quaternion
-import Rupert.RelatingRupertDefs
+import Rupert.Equivalences.RupertEquivRupertPrime
 
 namespace TriakisTetrahedron
 


### PR DESCRIPTION
This should make it more convenient to add more definitions and prove them equivalent without working in one big file.