### PR TITLE
Add definition of Affine Rupert Sets

### DIFF
--- a/Rupert.lean
+++ b/Rupert.lean
@@ -1,3 +1,4 @@
+import Rupert.Affine
 import Rupert.Attr
 import Rupert.Basic
 import Rupert.Convex
@@ -8,6 +9,7 @@ import Rupert.MatrixSimps
 import Rupert.Quaternion
 import Rupert.Equivalences.RupertEquivRupertPrime
 import Rupert.Equivalences.RupertEquivRupertSet
+import Rupert.Equivalences.AffineRupertEquivRupertSet
 import Rupert.Set
 import Rupert.SnubCube
 import Rupert.Square

--- a/Rupert/Affine.lean
+++ b/Rupert/Affine.lean
@@ -1,25 +1,22 @@
 import Mathlib
-import Rupert.Basic
-
-open scoped Matrix
 
 /-- The Rupert Property for a pair of subsets X, Y of an arbitrary
-    affine space. X has the Rupert property with respect to Y if there
-    exist affine isometries transforming X and Y respectively such
-    that the shadow of X transformed fits "comfortably" within the
-    shadow of Y transformed, after being projected to a maximal
-    nontrivial affine subspace. transformations.
+    finite-dimensional real affine space P. X has the Rupert property
+    with respect to Y if there exist
+    - affine isometries transforming X and Y respectively
+    - an maximal nontrivial affine subspace Q of P
+    such that the orthogonal projection onto Q of the transformed image of X fits
+    "comfortably" within the projection onto Q of the transformed image of Y.
 
     By "comfortably" we mean the closure of one set is a subset of the
     interior of the other. This definition rules out trivial cases of
     a set fitting inside itself. -/
 def IsAffineRupertPair {P : Type*} {V : Type*} [MetricSpace P] [NormedAddCommGroup V]
-    [InnerProductSpace ℝ V] [NormedAddTorsor V P]
+    [InnerProductSpace ℝ V] [NormedAddTorsor V P] [FiniteDimensional ℝ V]
     (inner outer : Set P) : Prop :=
     ∃ (inner_isometry outer_isometry : AffineIsometry ℝ P P)
-      (Q : AffineSubspace ℝ P) (_ : Nonempty Q) (_ : IsCoatom Q)
-      (_ : Q.direction.HasOrthogonalProjection), -- I don't want to depend on this as an argument
-    let proj := EuclideanGeometry.orthogonalProjection (V := V) (P := P) Q
+      (Q : AffineSubspace ℝ P) (_ : Nonempty Q) (_ : IsCoatom Q),
+    let proj := EuclideanGeometry.orthogonalProjection Q
     let inner_shadow := (proj ∘ inner_isometry) '' inner
     let outer_shadow: Set Q := (proj ∘ outer_isometry) '' outer
     closure inner_shadow ⊆ interior outer_shadow
@@ -27,6 +24,6 @@ def IsAffineRupertPair {P : Type*} {V : Type*} [MetricSpace P] [NormedAddCommGro
 /-- The Rupert Property for a subset S of affine space P. S has the Rupert property
     if it has the pairwise Rupert property with respect to itself. -/
 def IsAffineRupertSet  {P : Type*} {V : Type*} [MetricSpace P] [NormedAddCommGroup V]
-    [InnerProductSpace ℝ V] [NormedAddTorsor V P]
+    [InnerProductSpace ℝ V] [NormedAddTorsor V P] [FiniteDimensional ℝ V]
     (S : Set P) : Prop :=
     IsAffineRupertPair S S

--- a/Rupert/Affine.lean
+++ b/Rupert/Affine.lean
@@ -1,0 +1,32 @@
+import Mathlib
+import Rupert.Basic
+
+open scoped Matrix
+
+/-- The Rupert Property for a pair of subsets X, Y of an arbitrary
+    affine space. X has the Rupert property with respect to Y if there
+    exist affine isometries transforming X and Y respectively such
+    that the shadow of X transformed fits "comfortably" within the
+    shadow of Y transformed, after being projected to a maximal
+    nontrivial affine subspace. transformations.
+
+    By "comfortably" we mean the closure of one set is a subset of the
+    interior of the other. This definition rules out trivial cases of
+    a set fitting inside itself. -/
+def IsAffineRupertPair {P : Type*} {V : Type*} [MetricSpace P] [NormedAddCommGroup V]
+    [InnerProductSpace ℝ V] [NormedAddTorsor V P]
+    (inner outer : Set P) : Prop :=
+    ∃ (inner_isometry outer_isometry : AffineIsometry ℝ P P)
+      (Q : AffineSubspace ℝ P) (_ : Nonempty Q) (_ : IsCoatom Q)
+      (_ : Q.direction.HasOrthogonalProjection), -- I don't want to depend on this as an argument
+    let proj := EuclideanGeometry.orthogonalProjection (V := V) (P := P) Q
+    let inner_shadow := (proj ∘ inner_isometry) '' inner
+    let outer_shadow: Set Q := (proj ∘ outer_isometry) '' outer
+    closure inner_shadow ⊆ interior outer_shadow
+
+/-- The Rupert Property for a subset S of affine space P. S has the Rupert property
+    if it has the pairwise Rupert property with respect to itself. -/
+def IsAffineRupertSet  {P : Type*} {V : Type*} [MetricSpace P] [NormedAddCommGroup V]
+    [InnerProductSpace ℝ V] [NormedAddTorsor V P]
+    (S : Set P) : Prop :=
+    IsAffineRupertPair S S

--- a/Rupert/Equivalences/AffineRupertEquivRupertSet.lean
+++ b/Rupert/Equivalences/AffineRupertEquivRupertSet.lean
@@ -1,0 +1,8 @@
+import Mathlib
+import Rupert.Basic
+import Rupert.Set
+import Rupert.Affine
+import Rupert.Equivalences.Util
+open Matrix
+
+proof_wanted affine_rupert_iff_rupert_set (X : Set (EuclideanSpace ℝ (Fin 3))) :  IsAffineRupertSet X ↔ IsRupertSet X

--- a/Rupert/Equivalences/AffineRupertEquivRupertSet.lean
+++ b/Rupert/Equivalences/AffineRupertEquivRupertSet.lean
@@ -2,7 +2,5 @@ import Mathlib
 import Rupert.Basic
 import Rupert.Set
 import Rupert.Affine
-import Rupert.Equivalences.Util
-open Matrix
 
 proof_wanted affine_rupert_iff_rupert_set (X : Set (EuclideanSpace ℝ (Fin 3))) :  IsAffineRupertSet X ↔ IsRupertSet X


### PR DESCRIPTION
The goal of this progress is eventually to contribute this upstream to mathlib.

I'd like to workshop it here a bit first, though.

A must-have subgoal is proving `affine_rupert_iff_rupert_set` (of which this PR adds the statement) which relates it back to being a rupert set, which we have already related to being a rupert polyhedron.

An optional subgoal is proving something connecting the Nieuwland number being > 1 to the topological definition of "comfortably inside". But I'll have to do some looking around to see how to express the idea of an affine map shrinking a subset by a factor.