### PR TITLE
Avoid unnecessary tactic copy-pastes

### DIFF
--- a/Rupert/Tetrahedron.lean
+++ b/Rupert/Tetrahedron.lean
@@ -42,46 +42,25 @@ theorem rupert : IsRupert vertices := by
     refine Convex.ball_in_hull_of_corners_in_hull hε₀ ?_ ?_ ?_ ?_ <;>
       apply mem_convexHull_iff_exists_fintype.mpr <;>
       use Fin 4, inferInstance
-    · use ![14470757879961/43300505182000,
+    <;> [
+      use ![14470757879961/43300505182000,
             14426795957911/43300505182000,
             0,
-            900184459008/2706281573875]
-      use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
-      refine ⟨?_, ?_, ?_, ?_⟩
-      · intro i; fin_cases i <;> norm_num
-      · simp [Fin.sum_univ_four]; norm_num
-      · exact fun i ↦ ⟨i, rfl⟩
-      · simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices, Fin.sum_univ_four,
-                   ε₀, matrix_simps]
-        norm_num
-    · use ![72265247417243/216502525910000,
+            900184459008/2706281573875];
+      use ![72265247417243/216502525910000,
             72310753372299/216502525910000,
             0,
-            35963262560229/108251262955000]
-      use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
-      refine ⟨?_, ?_, ?_, ?_⟩
-      · intro i; fin_cases i <;> norm_num
-      · simp [Fin.sum_univ_four]; norm_num
-      · exact fun i ↦ ⟨i, rfl⟩
-      · simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices, Fin.sum_univ_four,
-                   ε₀, matrix_simps]
-        norm_num
-    · use ![14483649997239/43300505182000,
+            35963262560229/108251262955000];
+      use ![14483649997239/43300505182000,
             14462186725689/43300505182000,
             0,
-            897166778692/2706281573875]
-      use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
-      refine ⟨?_, ?_, ?_, ?_⟩
-      · intro i; fin_cases i <;> norm_num
-      · simp [Fin.sum_univ_four]; norm_num
-      · exact fun i ↦ ⟨i, rfl⟩
-      · simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices, Fin.sum_univ_four,
-                   ε₀, matrix_simps]
-        norm_num
-    · use ![72506791968757/216502525910000,
+            897166778692/2706281573875];
+      use ![72506791968757/216502525910000,
             72134160045701/216502525910000,
             0,
             35930786947771/108251262955000]
+    ]
+    all_goals
       use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
       refine ⟨?_, ?_, ?_, ?_⟩
       · intro i; fin_cases i <;> norm_num
@@ -100,55 +79,25 @@ theorem rupert : IsRupert vertices := by
   fin_cases y <;>
     simp only [vertices, Fin.reduceFinMk, Matrix.cons_val] at hy <;>
     use Fin 4, inferInstance
-  · use ![10743981448378145233579223/2255005124571996596714809125,
+  <;> [
+    use ![10743981448378145233579223/2255005124571996596714809125,
           64386129031453492435586819/13530030747431979580288854750,
           0,
-          13401180729710257216451792593/13530030747431979580288854750]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · intro i; fin_cases i <;> norm_num
-    · simp only [Fin.sum_univ_four, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices, Fin.sum_univ_four,
-                 inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![5556134647331086902480487669/6765015373715989790144427375,
+          13401180729710257216451792593/13530030747431979580288854750];
+    use ![5556134647331086902480487669/6765015373715989790144427375,
           2352935973121235655284086819/13530030747431979580288854750,
           0,
-          21608493216190040014597531/4510010249143993193429618250]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · intro i; fin_cases i <;> norm_num
-    · simp only [Fin.sum_univ_four, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices, Fin.sum_univ_four,
-                 inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![4608766371145456006819667/966430767673712827163489625,
+          21608493216190040014597531/4510010249143993193429618250];
+    use ![4608766371145456006819667/966430767673712827163489625,
           1914434962235023371784298117/1932861535347425654326979250,
           0,
-          3069680123370456843013933/644287178449141884775659750]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · intro i; fin_cases i <;> norm_num
-    · simp only [Fin.sum_univ_four, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices, Fin.sum_univ_four,
-                 inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![5556788588822333700340487669/6765015373715989790144427375,
+          3069680123370456843013933/644287178449141884775659750];
+    use ![5556788588822333700340487669/6765015373715989790144427375,
           64569206997427958451586819/13530030747431979580288854750,
           0,
           2351884362789884221156292593/13530030747431979580288854750]
+  ]
+  all_goals
     use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
     refine ⟨?_, ?_, ?_, ?_⟩
     · intro i; fin_cases i <;> norm_num
@@ -158,5 +107,5 @@ theorem rupert : IsRupert vertices := by
       simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices, Fin.sum_univ_four,
                  inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
       rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add,Matrix.vec2_add, Matrix.vec2_add]
+          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
       norm_num

--- a/Rupert/TriakisTetrahedron.lean
+++ b/Rupert/TriakisTetrahedron.lean
@@ -53,54 +53,33 @@ theorem rupert : IsRupert vertices := by
     refine Convex.ball_in_hull_of_corners_in_hull hε₀ ?_ ?_ ?_ ?_ <;>
       apply mem_convexHull_iff_exists_fintype.mpr <;>
       use Fin 8, Fin.fintype 8
-    · use ![0, 0, 0,
+    <;> [
+      use ![0, 0, 0,
             209107410810126884571/565617601328354816800,
             245824061168864729/35351100083022176050,
             0,
             70515401107905219313/113123520265670963360,
-            0]
-      use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
-      refine ⟨?_, ?_, ?_, ?_⟩
-      · apply all_fin_8_vec <;> norm_num
-      · simp [Fin.sum_univ_eight]; norm_num
-      · exact fun i ↦ ⟨i, rfl⟩
-      · simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-                   Fin.sum_univ_eight, ε₀, matrix_simps]
-        norm_num
-    · use ![0,
+            0];
+      use ![0,
             1051981313303264779479/2828088006641774084000,
             0,
             19719000787634436/6798288477504264625,
             353580717802170675829/565617601328354816800,
-            0, 0, 0]
-      use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
-      refine ⟨?_, ?_, ?_, ?_⟩
-      · apply all_fin_8_vec <;> norm_num
-      · simp [Fin.sum_univ_eight]; norm_num
-      · exact fun i ↦ ⟨i, rfl⟩
-      · simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-                   Fin.sum_univ_eight, ε₀, matrix_simps]
-        norm_num
-    · use ![3938334956654107739/8031045263445271000,
+            0, 0, 0];
+      use ![3938334956654107739/8031045263445271000,
             2045224314929433491/8031045263445271000,
             0,
             204748599186172977/803104526344527100,
-            0, 0, 0, 0]
-      use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
-      refine ⟨?_, ?_, ?_, ?_⟩
-      · apply all_fin_8_vec <;> norm_num
-      · simp [Fin.sum_univ_eight]; norm_num
-      · exact fun i ↦ ⟨i, rfl⟩
-      · simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-                   Fin.sum_univ_eight, ε₀, matrix_simps]
-        norm_num
-    · use ![0,
+            0, 0, 0, 0];
+      use ![0,
             1095105012905906001/353511000830221760500,
             0,
             1052120747247162610137/2828088006641774084000,
             0, 0,
             353441283858272845171/565617601328354816800,
             0]
+    ]
+    all_goals
       use fun i ↦ proj_xy (outer_rot *ᵥ vertices i)
       refine ⟨?_, ?_, ?_, ?_⟩
       · apply all_fin_8_vec <;> norm_num
@@ -119,45 +98,24 @@ theorem rupert : IsRupert vertices := by
   fin_cases y <;>
     simp only [vertices, Fin.reduceFinMk, Matrix.cons_val] at hy <;>
     use Fin 8, Fin.fintype 8
-  · use ![320050956502833201167751985054675539223111361/
+  <;> [
+    use ![320050956502833201167751985054675539223111361/
           158836228761182627011085302790150062539835294740000,
           37478789684155822552149249633100762035628799779/
           158836228761182627011085302790150062539835294740000,
           0,
           2646640498675699472588866429808865118371007380481/
           2647270479353043783518088379835834375663921579000,
-          0, 0, 0, 0]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · apply all_fin_8_vec <;> norm_num
-    · simp only [Fin.sum_univ_eight, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-        Fin.sum_univ_eight, inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![2690065380721338931107844675930079853008002249/
+          0, 0, 0, 0];
+    use ![2690065380721338931107844675930079853008002249/
           1429526058850643643099767725111350562858517652660000,
           1429185801354497250493132886580886682858320659198011/
           1429526058850643643099767725111350562858517652660000,
           0,
           5626123846094521128395511429799165339066424329/
           23825434314177394051662795418522509380975294211000,
-          0, 0, 0, 0]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · apply all_fin_8_vec <;> norm_num
-    · simp only [Fin.sum_univ_eight, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-        Fin.sum_univ_eight, inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![282844578280123522478732365155221962237373746450249/
+          0, 0, 0, 0];
+    use ![282844578280123522478732365155221962237373746450249/
           298290854644984786267344341448022649016038391108000,
           0, 0, 0,
           1716079538871724601954309613272108094228427903699/
@@ -165,19 +123,8 @@ theorem rupert : IsRupert vertices := by
           0,
           78025750787118551159488667585696530439676223/
           14914542732249239313367217072401132450801919555400,
-          0]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · apply all_fin_8_vec <;> norm_num
-    · simp only [Fin.sum_univ_eight, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-        Fin.sum_univ_eight, inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![283117566838487610246913017563019376237373746450249/
+          0];
+    use ![283117566838487610246913017563019376237373746450249/
           298290854644984786267344341448022649016038391108000,
           0, 0, 0,
           1574537650882650012051296636476848055851133291/
@@ -185,19 +132,8 @@ theorem rupert : IsRupert vertices := by
           0,
           758585663442314668520963629418339796530439676223/
           14914542732249239313367217072401132450801919555400,
-          0]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · apply all_fin_8_vec <;> norm_num
-    · simp only [Fin.sum_univ_eight, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-        Fin.sum_univ_eight, inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![15381264075549739501273188093551493041527383361/
+          0];
+    use ![15381264075549739501273188093551493041527383361/
           33143428293887198474149371272002516557337599012000,
           0, 0, 0,
           99383630567848375480456938122952631882685283711097/
@@ -205,57 +141,24 @@ theorem rupert : IsRupert vertices := by
           0,
           25526079328536174367806438713165510146558741/
           4971514244083079771122405690800377483600639851800,
-          0]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · apply all_fin_8_vec <;> norm_num
-    · simp only [Fin.sum_univ_eight, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-        Fin.sum_univ_eight, inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![31436375570010867744955561974649501075539223111361/
+          0];
+    use ![31436375570010867744955561974649501075539223111361/
           158836228761182627011085302790150062539835294740000,
           65162484389967530498892502615908096362035628799779/
           158836228761182627011085302790150062539835294740000,
           0,
           3111868440060211438361861909979623255113022141443/
           7941811438059131350554265139507503126991764737000,
-          0, 0, 0, 0]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · apply all_fin_8_vec <;> norm_num
-    · simp only [Fin.sum_univ_eight, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-        Fin.sum_univ_eight, inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![31418176332786595227076851814129673475539223111361/
+          0, 0, 0, 0];
+    use ![31418176332786595227076851814129673475539223111361/
           158836228761182627011085302790150062539835294740000,
           62237357220617638995747652173682152362035628799779/
           158836228761182627011085302790150062539835294740000,
           0,
           1086344920129639879804346646705637278371007380481/
           2647270479353043783518088379835834375663921579000,
-          0, 0, 0, 0]
-    use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
-    refine ⟨?_, ?_, ?_, ?_⟩
-    · apply all_fin_8_vec <;> norm_num
-    · simp only [Fin.sum_univ_eight, matrix_simps]; norm_num
-    · exact fun i ↦ ⟨proj_xy (outer_rot *ᵥ vertices i), by simp [outer_shadow]⟩
-    · rw [←hy]
-      simp only [proj_xy, outer_rot, matrix_of_quat, outer_quat, vertices,
-        Fin.sum_univ_eight, inner_offset, inner_rot, inner_quat, ε₁, matrix_simps]
-      rw [Matrix.smul_vec2, Matrix.smul_vec2, Matrix.smul_vec2,
-          Matrix.vec2_add, Matrix.vec2_add, Matrix.vec2_add]
-      norm_num
-  · use ![46105713581088386527939179642742079124582150083/
+          0, 0, 0, 0];
+    use ![46105713581088386527939179642742079124582150083/
           99430284881661595422448113816007549672012797036000,
           0, 0, 0,
           499295037844618876866011627687882685283711097/
@@ -264,6 +167,8 @@ theorem rupert : IsRupert vertices := by
           4969183993652133120852165431236855985510146558741/
           4971514244083079771122405690800377483600639851800,
           0]
+  ]
+  all_goals
     use fun i ↦ (1 - ε₁) • (proj_xy (outer_rot *ᵥ vertices i))
     refine ⟨?_, ?_, ?_, ?_⟩
     · apply all_fin_8_vec <;> norm_num


### PR DESCRIPTION
I hope this is helpful/not annoying. I noticed there was a lot of repeated tactic code in the tetrahedron and triakis tetrahedron proofs so I used the `seq_focus` combinator and `all_goals` to combine them.